### PR TITLE
add missing . to fix markdown ordered list

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,4 +32,4 @@ The recommended way to install FuzzyFileNav is via [Package Control](https://pac
     git clone https://github.com/facelessuser/FuzzyFileNav.git FuzzyFileNav
     ```
 
-3 Restart Sublime Text.
+3. Restart Sublime Text.


### PR DESCRIPTION
Very minor change to fix the formatting of the ordered list. See here for where the list was not properly indented: http://facelessuser.github.io/FuzzyFileNav/installation/