### PR TITLE
fix folders reference

### DIFF
--- a/fuzzy_file_nav.py
+++ b/fuzzy_file_nav.py
@@ -851,9 +851,9 @@ class FuzzyStartFromFileCommand(sublime_plugin.WindowCommand):
         if data is None:
             data = {}
         if "folders" not in data:
-            folders = []
+            data["folders"] = []
 
-        if len(folders):
+        if len(data["folders"]):
             self.window.run_command("fuzzy_project_folder_load")
         else:
             self.home()


### PR DESCRIPTION
This PR should fix the following error:

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 535, in run_
    return self.run()
  File "fuzzy_file_nav in C:\Users\chenp\AppData\Roaming\Sublime Text 3\Installed Packages\FuzzyFileNav.sublime-package", line 693, in run
  File "fuzzy_file_nav in C:\Users\chenp\AppData\Roaming\Sublime Text 3\Installed Packages\FuzzyFileNav.sublime-package", line 712, in project
UnboundLocalError: local variable 'folders' referenced before assignment
```

This happens when I'm trying to start from a project folder, i.e.
```json
{
    "start_from_here_default_action": "project"
}
```