### PR TITLE
Implementing some convenience suggestions

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -11,6 +11,11 @@
         "args": {"back": true}
     },
     {
+        "keys": ["backspace"],
+        "command": "fuzzy_go_to_parent_dir",
+        "context": [{"key": "fuzzy_go_to_parent_dir"}]
+    },
+    {
         "keys": ["ctrl+h"],
         "command": "fuzzy_toggle_hidden",
         "context": [{"key": "fuzzy_toggle_hidden"}]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -11,6 +11,11 @@
         "args": {"back": true}
     },
     {
+        "keys": ["backspace"],
+        "command": "fuzzy_go_to_parent_dir",
+        "context": [{"key": "fuzzy_go_to_parent_dir"}]
+    },
+    {
         "keys": ["super+h"],
         "command": "fuzzy_toggle_hidden",
         "context": [{"key": "fuzzy_toggle_hidden"}]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -11,6 +11,11 @@
         "args": {"back": true}
     },
     {
+        "keys": ["backspace"],
+        "command": "fuzzy_go_to_parent_dir",
+        "context": [{"key": "fuzzy_go_to_parent_dir"}]
+    },
+    {
         "keys": ["ctrl+h"],
         "command": "fuzzy_toggle_hidden",
         "context": [{"key": "fuzzy_toggle_hidden"}]

--- a/fuzzy_file_nav.sublime-settings
+++ b/fuzzy_file_nav.sublime-settings
@@ -22,6 +22,10 @@
     // nix     - this will complete like a unix/linux terminal traditionally completes paths
     "completion_style": "fuzzy",
 
+    // Whether to include the parent directory (..)
+    // in the files list
+    "include_parent_directory": true,
+
     // If the "FuzzyStartFromFileCommand" is run outside of a open buffer
     // or from a buffer that does not exist on disk, you can specify
     // its default action to do instead of starting navigation from


### PR DESCRIPTION
I just started tetsing out ST as a replacement for emacs, and this package is awesome! Thanks for all the work you've put into it.

I just have a few updates that I've been playing with to more closely replicate the experience I'm used to and I thought I'd see if you'd like to incorporate them.

Here's a summary of the changes:
- Add an option to remove the `..` option from the list
  - I find it enough to be able to type it out, and would prefer for the first item in the list to be a file option
- Sort the options by last access date if possible, and then alphabetically
  - I often find myself opening the same few files in a project, so it's nice if they always appear closer to the top of the list
- Pressing backspace when the input is empty goes up a drectory
  - This is taken from emacs ido-mode behaviour, where you can travel up the directory tree by deleting the previous segment
- Show the current directory as a placeholder
  - I found it kind of hard to see both the options and the status bar at the same time, but I do like to see which directory I'm currently looking at. This hopefully just makes that a little easier
  - It also attempts to keep the name short enough to read by replacing directories with their first letter inspired by fish shell

Feel free to make any changes, or reject them if you don't think they make sense to include.

Thanks again!
